### PR TITLE
workflows: drop node version 14 from automatic tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
 #        os: [ubuntu-20.04]
 #        node-version: [18]
         os: [ubuntu-22.04, ubuntu-20.04, windows-latest, macos-latest]
-        node-version: [14, 16, 18]
+        node-version: [16, 18]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
Nodejs 14.x is probably causing more issues than what it is being worth maintaining at least in the automatic tests.
