### PR TITLE
workflows: add 'depth' to the checkout action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,8 @@ jobs:
     - test
     steps:
     - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
     - run: git submodule update --init --recursive
     - name: List changes
       run: ./scripts/write-release-message.sh


### PR DESCRIPTION
By default the checkout action clones without tags and history, leading to the release description being empty due to:

fatal: No names found, cannot describe anything.

With 'depth: 0', the action should "fetch all history for all tags and branches" [1].

1. https://github.com/actions/checkout#fetch-all-history-for-all-tags-and-branches
